### PR TITLE
Fix: Resolve Port Conflict

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,6 +1,10 @@
 import { Elysia } from "elysia";
 
-const app = new Elysia().get("/", () => "Hello Elysia").listen(3000);
+const port = process.env.PORT || 3001;
+
+const app = new Elysia()
+  .get("/", () => "Hello Elysia")
+  .listen(port);
 
 console.log(
   `🦊 Elysia is running at ${app.server?.hostname}:${app.server?.port}`

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"


### PR DESCRIPTION
This PR updates the ElysiaJS backend to use the \PORT\ environment variable (defaulting to \3001\) and explicitly sets the Next.js frontend to run on port \3000\. Fixes #12.