### PR TITLE
DB: Implement Product Catalogue Schema & Seeder

### DIFF
--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -1,6 +1,7 @@
-import { pgTable, text, timestamp, pgEnum, primaryKey, integer } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, pgEnum, primaryKey, integer, jsonb } from "drizzle-orm/pg-core";
 
 export const roleEnum = pgEnum("role", ["USER", "SUPERADMIN"]);
+export const productTypeEnum = pgEnum("product_type", ["DIGITAL_DOWNLOAD", "WEBINAR", "COURSE"]);
 
 export const users = pgTable("user", {
   id: text("id")
@@ -58,3 +59,55 @@ export const verificationTokens = pgTable(
     }),
   })
 );
+
+// Base Product Table
+export const products = pgTable("product", {
+  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+  type: productTypeEnum("type").notNull(),
+  title: text("title").notNull(),
+  slug: text("slug").unique().notNull(),
+  description: jsonb("description"), // Rich-text JSON
+  price: integer("price").notNull(), // Store in cents
+  coverImage: text("cover_image"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+// Digital Downloads Extension
+export const digitalDownloads = pgTable("digital_download", {
+  productId: text("product_id").primaryKey().references(() => products.id, { onDelete: "cascade" }),
+});
+
+export const productResources = pgTable("product_resource", {
+  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+  productId: text("product_id").notNull().references(() => products.id, { onDelete: "cascade" }),
+  title: text("title").notNull(),
+  url: text("url").notNull(),
+});
+
+// Webinars Extension
+export const webinars = pgTable("webinar", {
+  productId: text("product_id").primaryKey().references(() => products.id, { onDelete: "cascade" }),
+  scheduledAt: timestamp("scheduled_at").notNull(),
+});
+
+// Courses Extension
+export const courses = pgTable("course", {
+  productId: text("product_id").primaryKey().references(() => products.id, { onDelete: "cascade" }),
+});
+
+export const courseSections = pgTable("course_section", {
+  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+  courseId: text("course_id").notNull().references(() => courses.productId, { onDelete: "cascade" }),
+  title: text("title").notNull(),
+  order: integer("order").notNull(),
+});
+
+export const courseLessons = pgTable("course_lesson", {
+  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+  sectionId: text("section_id").notNull().references(() => courseSections.id, { onDelete: "cascade" }),
+  title: text("title").notNull(),
+  description: jsonb("description"),
+  videoUrl: text("video_url"),
+  order: integer("order").notNull(),
+});

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -1,33 +1,109 @@
 import { eq } from "drizzle-orm";
 import { db } from "./db";
-import { users } from "./schema";
+import { 
+  users, 
+  products, 
+  webinars, 
+  courses, 
+  courseSections, 
+  courseLessons, 
+  digitalDownloads, 
+  productResources 
+} from "./schema";
 
 async function seed() {
-  // Read the desired Superadmin email from environment variables
+  // 1. Seed Superadmin
   const adminEmail = process.env.ADMIN_EMAIL;
-
-  if (!adminEmail) {
-    console.error("❌ ADMIN_EMAIL environment variable is not set. Please add it to your .env file.");
-    process.exit(1);
+  if (adminEmail) {
+    console.log(`🌱 Seeding SUPERADMIN: ${adminEmail}`);
+    await db.update(users).set({ role: "SUPERADMIN" }).where(eq(users.email, adminEmail));
   }
 
-  console.log(`🌱 Attempting to seed SUPERADMIN role for: ${adminEmail}`);
+  // 2. Seed Catalogue
+  console.log("🌱 Seeding Product Catalogue...");
 
   try {
-    // Forcefully update the user's role in the database
-    // We update rather than create, because OAuth creation is complex
-    const result = await db
-      .update(users)
-      .set({ role: "SUPERADMIN" })
-      .where(eq(users.email, adminEmail))
-      .returning();
+    // Clear existing products (optional, but good for clean seed)
+    // await db.delete(products); 
 
-    if (result.length > 0) {
-      console.log(`✅ Success: User ${adminEmail} is now a SUPERADMIN.`);
-    } else {
-      console.log(`⚠️ User not found.`);
-      console.log(`👉 You must log in via Google OAuth on the Frontend first to create the initial user record.`);
-    }
+    // --- DIGITAL DOWNLOAD ---
+    const [downloadProduct] = await db.insert(products).values({
+      type: "DIGITAL_DOWNLOAD",
+      title: "Creator's Ultimate Toolkit",
+      slug: "creators-ultimate-toolkit",
+      description: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "A comprehensive set of templates and resources for modern creators." }] }]
+      },
+      price: 4900, // $49.00
+      coverImage: "https://images.unsplash.com/photo-1614332287897-cdc485fa562d?q=80&w=1000&auto=format&fit=crop",
+    }).returning();
+
+    await db.insert(digitalDownloads).values({ productId: downloadProduct.id });
+    await db.insert(productResources).values([
+      { productId: downloadProduct.id, title: "Social Media Calendar Template", url: "https://example.com/files/calendar.pdf" },
+      { productId: downloadProduct.id, title: "Budgeting Spreadsheet", url: "https://example.com/files/budget.xlsx" },
+    ]);
+
+    // --- WEBINAR ---
+    const nextWeek = new Date();
+    nextWeek.setDate(nextWeek.getDate() + 7);
+
+    const [webinarProduct] = await db.insert(products).values({
+      type: "WEBINAR",
+      title: "Mastering Personal Branding 2026",
+      slug: "mastering-personal-branding-2026",
+      description: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "Join our live session to learn how to build a brand that lasts." }] }]
+      },
+      price: 2900, // $29.00
+      coverImage: "https://images.unsplash.com/photo-1540575861501-7ad0582373f2?q=80&w=1000&auto=format&fit=crop",
+    }).returning();
+
+    await db.insert(webinars).values({
+      productId: webinarProduct.id,
+      scheduledAt: nextWeek,
+    });
+
+    // --- COURSE ---
+    const [courseProduct] = await db.insert(products).values({
+      type: "COURSE",
+      title: "NextJS 16 Deep Dive",
+      slug: "nextjs-16-deep-dive",
+      description: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "From zero to hero in the latest version of NextJS." }] }]
+      },
+      price: 9900, // $99.00
+      coverImage: "https://images.unsplash.com/photo-1618477388954-7852f32655ec?q=80&w=1000&auto=format&fit=crop",
+    }).returning();
+
+    await db.insert(courses).values({ productId: courseProduct.id });
+
+    const [section1] = await db.insert(courseSections).values({
+      courseId: courseProduct.id,
+      title: "Getting Started",
+      order: 1,
+    }).returning();
+
+    await db.insert(courseLessons).values([
+      { sectionId: section1.id, title: "Introduction to NextJS 16", order: 1, videoUrl: "https://youtube.com/embed/dQw4w9WgXcQ" },
+      { sectionId: section1.id, title: "Environment Setup", order: 2, videoUrl: "https://youtube.com/embed/dQw4w9WgXcQ" },
+    ]);
+
+    const [section2] = await db.insert(courseSections).values({
+      courseId: courseProduct.id,
+      title: "Advanced Routing",
+      order: 2,
+    }).returning();
+
+    await db.insert(courseLessons).values([
+      { sectionId: section2.id, title: "Parallel Routes", order: 1, videoUrl: "https://youtube.com/embed/dQw4w9WgXcQ" },
+      { sectionId: section2.id, title: "Intercepting Routes", order: 2, videoUrl: "https://youtube.com/embed/dQw4w9WgXcQ" },
+    ]);
+
+    console.log("✅ Catalogue seeded successfully!");
   } catch (error) {
     console.error("❌ Error running seed script:", error);
   } finally {


### PR DESCRIPTION
### Summary
This PR implements the initial database schema for the Product Catalogue and provides a seeder script for testing.

### Changes
- **Schema**: Added tables for product, digital_download, product_resource, webinar, course, course_section, and course_lesson in packages/database/src/schema.ts.
- **Seeder**: Updated packages/database/src/seed.ts to populate the catalogue with test data for each product type.
- **Migration**: Generated initial migration files.

Fixes #18